### PR TITLE
Drop failovermethod=priority from repositories

### DIFF
--- a/fedora-updates.repo.in
+++ b/fedora-updates.repo.in
@@ -1,6 +1,5 @@
 [updates]
 name=Fedora %FCREL% - x86_64 - Updates
-failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/%FCREL%/x86_64/
 metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-f%FCREL%&arch=x86_64
 enabled=1
@@ -10,7 +9,6 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-%FCREL%-primary
 
 [updates-debuginfo]
 name=Fedora %FCREL% - x86_64 - Updates - Debug
-failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/%FCREL%/x86_64/debug/
 metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f%FCREL%&arch=x86_64
 enabled=0
@@ -20,7 +18,6 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-%FCREL%-primary
 
 [updates-source]
 name=Fedora %FCREL% - Updates Source
-failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/updates/%FCREL%/SRPMS/
 metalink=https://mirrors.fedoraproject.org/metalink?repo=updates-released-source-f%FCREL%&arch=x86_64
 enabled=0

--- a/fedora.repo.in
+++ b/fedora.repo.in
@@ -1,6 +1,5 @@
 [fedora]
 name=Fedora %FCREL% - x86_64
-failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/%FCREL%/Everything/x86_64/os/
 metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-%FCREL%&arch=x86_64
 enabled=1
@@ -11,7 +10,6 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-%FCREL%-primary
 
 [fedora-debuginfo]
 name=Fedora %FCREL% - x86_64 - Debug
-failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/%FCREL%/Everything/x86_64/debug/
 metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-%FCREL%&arch=x86_64
 enabled=0
@@ -22,7 +20,6 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-%FCREL%-primary
 
 [fedora-source]
 name=Fedora %FCREL% - Source
-failovermethod=priority
 #baseurl=http://download.fedoraproject.org/pub/fedora/linux/releases/%FCREL%/Everything/source/SRPMS/
 metalink=https://mirrors.fedoraproject.org/metalink?repo=fedora-source-%FCREL%&arch=x86_64
 enabled=0


### PR DESCRIPTION
It doesn't exist anymore

Fixes QubesOS/qubes-issues#6581