### PR TITLE
Leave out wl-clipboard in qubes-kickstart.cfg

### DIFF
--- a/conf/qubes-kickstart.cfg
+++ b/conf/qubes-kickstart.cfg
@@ -72,6 +72,7 @@ kernel-latest-qubes-vm
 -systemd-networkd
 -systemd-resolved
 -trousers
+-wl-clipboard
 -xorg-x11-fonts-misc
 -xdg-desktop-portal-gtk
 # selected dependencies


### PR DESCRIPTION
When a package depends on, say, `xsel | xclip | wl-clipboard`, prefer X11 path and avoid pulling in Wayland version with dependencies.