### PR TITLE
comps: do not install dracut-config-rescue

### DIFF
--- a/comps/comps-dom0.xml
+++ b/comps/comps-dom0.xml
@@ -598,8 +598,8 @@
       <packagereq type="mandatory">vim-minimal</packagereq>
       <packagereq type="mandatory">yum</packagereq>
       <packagereq type="default">dnf5-plugins</packagereq>
-      <packagereq type="default">dracut-config-rescue</packagereq>
       <!--
+      <packagereq type="default">dracut-config-rescue</packagereq>
       <packagereq type="default">firewalld</packagereq>
       -->
       <packagereq type="default">fwupd</packagereq>


### PR DESCRIPTION
The generated rescue initramfs is not referenced by any boot entry, and
it uses over 200M of /boot space (so, 20% of it).